### PR TITLE
Fix condition where the same entry is made twice.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "sg" {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = concat(var.command_center_cidrs, var.trustprovider_cidrs)
+    cidr_blocks = distinct(concat(var.command_center_cidrs, var.trustprovider_cidrs))
     description = "Command Center and TrustProvider"
   }
 


### PR DESCRIPTION
When making a rule in a security group, if the rule is the same, terraform will try and make it twice, but AWS will consolidate out the duplicate.  This fix does that before applying it to AWS so that whenever terraform is run it won't try to remove the rule with one entry and the replace it again with the same rule twice.